### PR TITLE
Export a factory function in order to avoid sharing timers between instances.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,3 @@
 {
-  "optional": [
-    "es7.objectRestSpread"
-  ]
+  "presets": ["es2015"]
 }

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ To enable Redux Debounce:
 
 ```js
 import { createStore, applyMiddleware } from 'redux';
-import debounce from 'redux-debounced';
+import createDebounce from 'redux-debounced';
 import rootReducer from './reducers/index';
 
 // create a store that has redux-thunk middleware enabled
 const createStoreWithMiddleware = applyMiddleware(
-  debounce
+  createDebounce()
 )(createStore);
 
 const store = createStoreWithMiddleware(rootReducer);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-core": "^6.6.5",
-    "babel-istanbul": "^0.3.20",
+    "babel-istanbul": "^0.3.1",
+    "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "chai": "^3.3.0",
     "mocha": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   },
   "homepage": "https://github.com/ryanseddon/redux-debounce#readme",
   "devDependencies": {
-    "babel": "^5.8.23",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.6.5",
     "babel-istanbul": "^0.3.20",
+    "babel-preset-es2015": "^6.6.0",
     "chai": "^3.3.0",
     "mocha": "^2.3.3",
     "redux": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Debounce middleware for Redux",
   "main": "lib/index.js",
   "scripts": {
-    "test": "babel-istanbul cover _mocha && babel-istanbul check-coverage --branches 90",
+    "test": "babel-node node_modules/.bin/babel-istanbul cover _mocha && babel-node node_modules/.bin/babel-istanbul check-coverage --branches 90",
     "build": "rm -rf lib/ && babel -d lib/ src/",
     "prepublish": "npm run build"
   },
@@ -21,7 +21,7 @@
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-core": "^6.6.5",
-    "babel-istanbul": "^0.3.1",
+    "babel-istanbul": "^0.6.1",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "chai": "^3.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,31 @@
-export let timers = {};
+export default () => {
+  let timers = {};
 
-export default () => dispatch => action => {
-  const {
-    meta: { debounce={} }={},
-    type
-  } = action;
+  const middleware = () => dispatch => action => {
+    const {
+      meta: { debounce={} }={},
+      type
+    } = action;
 
-  const {
-    time,
-    key = type
-  } = debounce;
+    const {
+      time,
+      key = type
+    } = debounce;
 
-  if (!time || !key) {
-    return dispatch(action);
-  }
+    if (!time || !key) {
+      return dispatch(action);
+    }
 
-  if (timers[key]) {
-    clearTimeout(timers[key]);
-  }
+    if (timers[key]) {
+      clearTimeout(timers[key]);
+    }
 
-  timers[key] = setTimeout(() => {
-    dispatch(action);
-  }, time);
+    timers[key] = setTimeout(() => {
+      dispatch(action);
+    }, time);
+  };
+
+  middleware._timers = timers;
+
+  return middleware;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,14 +1,16 @@
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createStore, applyMiddleware } from 'redux';
-import debounce, { timers } from '../src';
+import createDebounce from '../src';
 
 describe('debounce middleware', () => {
   let store;
   let clock;
+  let timers;
 
   beforeEach(() => {
     let increment = 0;
+    const debounce = createDebounce();
     const createStoreWithMiddleware = applyMiddleware(debounce)(createStore);
     const initialState = {};
     const reducer = (state = initialState, action) => {
@@ -20,12 +22,12 @@ describe('debounce middleware', () => {
           };
         }
 
-      case 'UPDATE': {
-        return {
-          ...state,
-          increment: increment+1
+        case 'UPDATE': {
+          return {
+            ...state,
+            increment: increment+1
+          }
         }
-      }
 
         default: {
           return state;
@@ -34,6 +36,7 @@ describe('debounce middleware', () => {
     }
     store = createStoreWithMiddleware(reducer, initialState);
     clock = useFakeTimers();
+    timers = debounce._timers;
     spy(store, 'dispatch');
     spy(global, 'setTimeout');
   });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---compilers js:babel-core/register

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel/register
+--compilers js:babel-core/register


### PR DESCRIPTION
Fixes #5.
