### PR TITLE
Add ability to cancel debounced action

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ const action = {
 };
 ```
 
+### Cancelling a Debounced Action (Advanced)
+
 If you need to cancel a debounced action, you can set the `cancel` flag to true:
 
 ```
@@ -89,6 +91,10 @@ const otherAction = {
 This works in conjunction with the custom `key` metadata.  This can be useful if
 one action may need to cancel another debounced action (e.g., a debounced API
 call that does not need to run if another action comes in).
+
+*Important* - A cancel action will terminate in the middleware without
+propagating further.  It will not show up DevTools or cause other side effects.
+So you cannot "piggyback" a cancel on another call at this time.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,35 @@ const action = {
 };
 ```
 
+If you need to cancel a debounced action, you can set the `cancel` flag to true:
+
+```
+const action = {
+  type: 'MY_ACTION',
+  meta: {
+    debounce: {
+      cancel: true
+    }
+  }
+};
+
+// OR
+
+const otherAction = {
+  type: 'CANCEL_OTHER_ACTION',
+  meta: {
+    debounce: {
+      cancel: true,
+      key: 'MY_ACTION'
+    }
+  }
+}
+```
+
+This works in conjunction with the custom `key` metadata.  This can be useful if
+one action may need to cancel another debounced action (e.g., a debounced API
+call that does not need to run if another action comes in).
+
 ## License
 
 [MIT License](http://ryanseddon.mit-license.org/)

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,13 @@ export default () => {
 
     const {
       time,
-      key = type
+      key = type,
+      cancel = false
     } = debounce;
 
-    if (!time || !key) {
+    const shouldDebounce = (time && key) || (cancel && key);
+
+    if (!shouldDebounce) {
       return dispatch(action);
     }
 
@@ -20,9 +23,11 @@ export default () => {
       clearTimeout(timers[key]);
     }
 
-    timers[key] = setTimeout(() => {
+    if (!cancel) {
+      timers[key] = setTimeout(() => {
       dispatch(action);
-    }, time);
+      }, time);
+    }
   };
 
   middleware._timers = timers;

--- a/test/index.js
+++ b/test/index.js
@@ -145,4 +145,40 @@ describe('debounce middleware', () => {
       assert.deepEqual(store.getState(), {increment:1});
     });
   });
+
+  describe('debounced action can be cancelled', () => {
+    const action = {
+      type: 'UPDATE',
+      meta: {
+        debounce: {time: 300}
+      }
+    };
+    const actionCancel = {
+      type: 'CANCEL_UPDATE',
+      meta: {
+        debounce: {
+          key: 'UPDATE',
+          cancel: true
+        }
+      }
+    };
+    beforeEach(() => {
+      spy(global, 'clearTimeout');
+      global.clearTimeout.reset();
+      global.setTimeout.reset();
+      store.dispatch(action);
+      store.dispatch(action);
+      store.dispatch(actionCancel);
+    });
+    it('setTimeout is called twice', () => {
+      assert.ok(global.setTimeout.calledTwice);
+    });
+    it('clearTimeout is called three times', () => {
+      assert.ok(global.clearTimeout.calledTwice);
+    });
+    it('state will not update', () => {
+      clock.tick(300);
+      assert.deepEqual(store.getState(), {});
+    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -153,6 +153,7 @@ describe('debounce middleware', () => {
         debounce: {time: 300}
       }
     };
+
     const actionCancel = {
       type: 'CANCEL_UPDATE',
       meta: {
@@ -162,6 +163,7 @@ describe('debounce middleware', () => {
         }
       }
     };
+
     beforeEach(() => {
       spy(global, 'clearTimeout');
       global.clearTimeout.reset();
@@ -170,12 +172,15 @@ describe('debounce middleware', () => {
       store.dispatch(action);
       store.dispatch(actionCancel);
     });
+
     it('setTimeout is called twice', () => {
       assert.ok(global.setTimeout.calledTwice);
     });
+
     it('clearTimeout is called three times', () => {
       assert.ok(global.clearTimeout.calledTwice);
     });
+
     it('state will not update', () => {
       clock.tick(300);
       assert.deepEqual(store.getState(), {});


### PR DESCRIPTION
I have a specific use case where I want to cancel a debounced action if a second action happens before the debounce resolves.  This PR adds this ability via an additional property to the `debounce` metadata.

The example is a "username or email address" input form that can provides an autocomplete list populated from an API.  The API call is debounced so that it only happens after 300ms of no changes to the input field.  However, the user can also hit "return" to enter the input immediately which resets the input field for the next username or email entry.  In the case where return is hit before the API call runs, I want to cancel the pending debounced API call which this PR solves.

Let me know if this makes sense for the lib!
