### PR TITLE
Immediate debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ const action = {
 };
 ```
 
+### Leading or trailing debouncing
+
+You can specify if the action should be dispatch on the leading and/or trailing edge of the debounce. This implementation is similar to the lodash `_.debounce()` method. By default, `leading = false` and `trailing = true`. If both values are set to `false`, the action will not be debounced.
+
+```js
+const action = {
+  type: 'MY_ACTION',
+  meta: {
+    debounce: {
+      time: 300,
+      // The action will be dispatched at the beginning of the debounce and not at the end
+      leading: true,
+      trailing: false
+    }
+  }
+};
+```
+
 ### Cancelling a Debounced Action (Advanced)
 
 If you need to cancel a debounced action, you can set the `cancel` flag to true:

--- a/src/index.js
+++ b/src/index.js
@@ -2,18 +2,30 @@ export default () => {
   let timers = {};
 
   const middleware = () => dispatch => action => {
-    const {
-      meta: { debounce={} }={},
-      type
-    } = action;
+    const { meta: { debounce = {} } = {}, type } = action;
 
     const {
       time,
       key = type,
-      cancel = false
+      cancel = false,
+      leading = false,
+      trailing = true
     } = debounce;
 
-    const shouldDebounce = (time && key) || (cancel && key);
+    const shouldDebounce =
+      ((time && key) || (cancel && key)) && (trailing || leading);
+    const dispatchNow = leading && !timers[key];
+
+    const later = () => {
+      if (trailing && !dispatchNow) {
+        return new Promise(resolve => {
+          timers[key] = setTimeout(() => {
+            resolve(dispatch(action));
+          }, time);
+        });
+      }
+      timers[key] = null;
+    };
 
     if (!shouldDebounce) {
       return dispatch(action);
@@ -21,14 +33,19 @@ export default () => {
 
     if (timers[key]) {
       clearTimeout(timers[key]);
+      timers[key] = null;
     }
 
     if (!cancel) {
-      return new Promise(resolve => {
-        timers[key] = setTimeout(() => {
-          resolve(dispatch(action));
-        }, time);
-      })
+      if (dispatchNow) {
+        return new Promise(resolve => {
+          timers[key] = setTimeout(() => {
+            resolve(dispatch(action));
+          }, time);
+        });
+      }
+
+      timers[key] = setTimeout(later, time);
     }
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export default () => {
-  let timers = {};
+  const timers = {};
 
   const middleware = () => dispatch => action => {
     const { meta: { debounce = {} } = {}, type } = action;
@@ -16,13 +16,9 @@ export default () => {
       ((time && key) || (cancel && key)) && (trailing || leading);
     const dispatchNow = leading && !timers[key];
 
-    const later = () => {
+    const later = resolve => () => {
       if (trailing && !dispatchNow) {
-        return new Promise(resolve => {
-          timers[key] = setTimeout(() => {
-            resolve(dispatch(action));
-          }, time);
-        });
+        resolve(dispatch(action));
       }
       timers[key] = null;
     };
@@ -37,15 +33,12 @@ export default () => {
     }
 
     if (!cancel) {
-      if (dispatchNow) {
-        return new Promise(resolve => {
-          timers[key] = setTimeout(() => {
-            resolve(dispatch(action));
-          }, time);
-        });
-      }
-
-      timers[key] = setTimeout(later, time);
+      return new Promise(resolve => {
+        if (dispatchNow) {
+          resolve(dispatch(action));
+        }
+        timers[key] = setTimeout(later(resolve), time);
+      });
     }
   };
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,9 @@
-import { assert } from 'chai';
-import { spy, useFakeTimers } from 'sinon';
-import { createStore, applyMiddleware } from 'redux';
-import createDebounce from '../src';
+import { assert } from "chai";
+import { spy, useFakeTimers } from "sinon";
+import { createStore, applyMiddleware } from "redux";
+import createDebounce from "../src";
 
-describe('debounce middleware', () => {
+describe("debounce middleware", () => {
   let store;
   let clock;
   let timers;
@@ -15,161 +15,165 @@ describe('debounce middleware', () => {
     const initialState = {};
     const reducer = (state = initialState, action) => {
       switch (action.type) {
-        case 'SEARCH': {
+        case "SEARCH": {
           return {
             ...state,
             query: action.payload
           };
         }
 
-        case 'UPDATE': {
+        case "UPDATE": {
           return {
             ...state,
             increment: (state.increment || 0) + 1
-          }
+          };
         }
 
         default: {
           return state;
         }
       }
-    }
+    };
     store = createStoreWithMiddleware(reducer, initialState);
     clock = useFakeTimers();
     timers = debounce._timers;
-    spy(store, 'dispatch');
-    spy(global, 'setTimeout');
+    spy(store, "dispatch");
+    spy(global, "setTimeout");
   });
 
-  describe('debounced action is dispatched', () => {
+  describe("debounced action is dispatched", () => {
     const timeout = 300;
 
     beforeEach(() => {
       store.dispatch({
-        type: 'SEARCH',
-        payload: 'foo',
+        type: "SEARCH",
+        payload: "foo",
         meta: {
           debounce: { time: timeout }
         }
-      })
+      });
     });
 
-    it('dispatch is only called once', () => {
+    it("dispatch is only called once", () => {
       assert.equal(store.dispatch.callCount, 1);
     });
 
-    it('timers object contains key matching action', () => {
+    it("timers object contains key matching action", () => {
       assert.ok(timers.SEARCH);
     });
 
-    it('state is unchanged from initialState', () => {
+    it("state is unchanged from initialState", () => {
       assert.deepEqual(store.getState(), {});
     });
 
-    it('setTimeout is called', () => {
+    it("setTimeout is called", () => {
       assert.equal(global.setTimeout.callCount, 1);
     });
 
-    it('state is updated when timeout elapses', () => {
+    it("state is updated when timeout elapses", () => {
       clock.tick(timeout);
-      assert.deepEqual(store.getState(), {query:'foo'});
+      assert.deepEqual(store.getState(), { query: "foo" });
     });
   });
 
-  describe('debounced action with time and key', () => {
+  describe("debounced action with time and key", () => {
     const timeout = 300;
-    const key = 'query';
+    const key = "query";
 
     beforeEach(() => {
       store.dispatch({
-        type: 'SEARCH',
-        payload: 'foo',
+        type: "SEARCH",
+        payload: "foo",
         meta: {
           debounce: { time: timeout, key: key }
         }
-      })
+      });
     });
 
-    it('timers object should contain item matching key', () => {
+    it("timers object should contain item matching key", () => {
       assert.ok(timers.query);
     });
   });
 
-  describe('debounced action is dispatched with no time', () => {
-    beforeEach(() => store.dispatch({
-      type: 'SEARCH',
-      payload: 'foo',
-      meta: {
-        debounce: {}
-      }
-    }));
+  describe("debounced action is dispatched with no time", () => {
+    beforeEach(() =>
+      store.dispatch({
+        type: "SEARCH",
+        payload: "foo",
+        meta: {
+          debounce: {}
+        }
+      })
+    );
 
-    it('state is updated straight away', () => {
-      assert.deepEqual(store.getState(), {query:'foo'});
+    it("state is updated straight away", () => {
+      assert.deepEqual(store.getState(), { query: "foo" });
     });
   });
 
-  describe('action is dispatched even has meta without debounce', () => {
-    beforeEach(() => store.dispatch({
-      type: 'SEARCH',
-      payload: 'foo',
-      meta: { other: 'other' }
-    }));
+  describe("action is dispatched even has meta without debounce", () => {
+    beforeEach(() =>
+      store.dispatch({
+        type: "SEARCH",
+        payload: "foo",
+        meta: { other: "other" }
+      })
+    );
 
-    it('state is updated straight away', () => {
-      assert.deepEqual(store.getState(), {query:'foo'});
+    it("state is updated straight away", () => {
+      assert.deepEqual(store.getState(), { query: "foo" });
     });
   });
 
-  describe('debounced action is fired many times', () => {
+  describe("debounced action is fired many times", () => {
     const action = {
-      type: 'UPDATE',
+      type: "UPDATE",
       meta: {
-        debounce: {time:300}
+        debounce: { time: 300 }
       }
     };
 
     beforeEach(() => {
-      spy(global, 'clearTimeout');
+      spy(global, "clearTimeout");
       store.dispatch(action);
       store.dispatch(action);
       store.dispatch(action);
     });
 
-    it('clearTimeout is called twice', () => {
+    it("clearTimeout is called twice", () => {
       assert.ok(global.clearTimeout.calledTwice);
     });
 
-    it('dispatch is called three times', () => {
+    it("dispatch is called three times", () => {
       assert.ok(store.dispatch.calledThrice);
     });
 
     it(`state will only update once per ${action.meta.debounce.time}ms`, () => {
       clock.tick(300);
-      assert.deepEqual(store.getState(), {increment:1});
+      assert.deepEqual(store.getState(), { increment: 1 });
     });
   });
 
-  describe('debounced action can be cancelled', () => {
+  describe("debounced action can be cancelled", () => {
     const action = {
-      type: 'UPDATE',
+      type: "UPDATE",
       meta: {
-        debounce: {time: 300}
+        debounce: { time: 300 }
       }
     };
 
     const actionCancel = {
-      type: 'CANCEL_UPDATE',
+      type: "CANCEL_UPDATE",
       meta: {
         debounce: {
-          key: 'UPDATE',
+          key: "UPDATE",
           cancel: true
         }
       }
     };
 
     beforeEach(() => {
-      spy(global, 'clearTimeout');
+      spy(global, "clearTimeout");
       global.clearTimeout.reset();
       global.setTimeout.reset();
       store.dispatch(action);
@@ -177,37 +181,135 @@ describe('debounce middleware', () => {
       store.dispatch(actionCancel);
     });
 
-    it('setTimeout is called twice', () => {
+    it("setTimeout is called twice", () => {
       assert.ok(global.setTimeout.calledTwice);
     });
 
-    it('clearTimeout is called twice', () => {
+    it("clearTimeout is called twice", () => {
       assert.ok(global.clearTimeout.calledTwice);
     });
 
-    it('state will not update', () => {
+    it("state will not update", () => {
       clock.tick(300);
       assert.deepEqual(store.getState(), {});
     });
   });
 
-  describe('using redux-thunk', () => {
+  describe("using redux-thunk", () => {
     const action = {
-      type: 'UPDATE',
+      type: "UPDATE",
       meta: {
-        debounce: {time:300}
+        debounce: { time: 300 }
       }
     };
 
-    it('should work calling `then` on dispatch', done => {
-      store.dispatch(action)
+    it("should work calling `then` on dispatch", done => {
+      store
+        .dispatch(action)
         .then(() => {
-          assert.deepEqual(store.getState(), {increment: 1});
+          assert.deepEqual(store.getState(), { increment: 1 });
           done();
         })
         .catch(err => done(err));
 
       clock.tick(300);
+    });
+  });
+
+  describe("leading debounced action are called once at the beginning", () => {
+    const action = {
+      type: "UPDATE",
+      meta: {
+        debounce: {
+          time: 300,
+          leading: true,
+          trailing: false
+        }
+      }
+    };
+
+    beforeEach(() => {
+      spy(global, "clearTimeout");
+      global.clearTimeout.reset();
+      global.setTimeout.reset();
+      store.dispatch(action);
+      store.dispatch(action);
+      store.dispatch(action);
+    });
+
+    it("setTimeout is called three times", () => {
+      assert.ok(global.setTimeout.calledThrice);
+    });
+
+    it("state will update once on the first action", () => {
+      assert.deepEqual(store.getState(), { increment: 1 });
+      clock.tick(400);
+      assert.deepEqual(store.getState(), { increment: 1 });
+    });
+  });
+
+  describe("leading debounced action are called again if time is elapsed", () => {
+    const action = {
+      type: "UPDATE",
+      meta: {
+        debounce: {
+          time: 300,
+          leading: true,
+          trailing: false
+        }
+      }
+    };
+
+    beforeEach(() => {
+      spy(global, "clearTimeout");
+      global.clearTimeout.reset();
+      global.setTimeout.reset();
+      store.dispatch(action);
+      store.dispatch(action);
+      clock.tick(500);
+      store.dispatch(action);
+    });
+
+    it("setTimeout is called thrice", () => {
+      assert.ok(global.setTimeout.calledThrice);
+    });
+
+    it("state will update once on the first action", () => {
+      assert.deepEqual(store.getState(), { increment: 2 });
+    });
+  });
+
+  describe("leading and trailing debounced action can work together", () => {
+    const action = {
+      type: "UPDATE",
+      meta: {
+        debounce: {
+          time: 300,
+          leading: true,
+          trailing: true
+        }
+      }
+    };
+
+    beforeEach(() => {
+      spy(global, "clearTimeout");
+      global.clearTimeout.reset();
+      global.setTimeout.reset();
+      store.dispatch(action);
+      clock.tick(100);
+      store.dispatch(action);
+      clock.tick(100);
+      store.dispatch(action);
+    });
+
+    it("setTimeout is called thrice", () => {
+      assert.ok(global.setTimeout.calledThrice);
+    });
+
+    it("state will update once on leading and trailing edge", () => {
+      assert.deepEqual(store.getState(), { increment: 1 });
+      clock.tick(400);
+      assert.deepEqual(store.getState(), { increment: 2 });
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ describe('debounce middleware', () => {
         case 'UPDATE': {
           return {
             ...state,
-            increment: increment+1
+            increment: (state.increment || 0) + 1
           }
         }
 
@@ -181,7 +181,7 @@ describe('debounce middleware', () => {
       assert.ok(global.setTimeout.calledTwice);
     });
 
-    it('clearTimeout is called three times', () => {
+    it('clearTimeout is called twice', () => {
       assert.ok(global.clearTimeout.calledTwice);
     });
 


### PR DESCRIPTION
## First commit : Fixed minor bugs in tests
- Corrected a bug where `state.increment` wouldn't update correctly.
- Corrected a small typo in the cancel test description.
## Second commit : Debounce can be set to dispatch on leading and/or trailing edge
- Added `leading` and `trailing` booleans to describe if the action should be dispatch on the first and/or last bounce.
- `shouldDebounce` is now false if both `leading` and `trailing` are false (no dispatch would be send).
- Added `timers[key] = null` to ensure actions will be correctly dispatched.

**Warning** : The interactions with the `cancel` boolean may be worth testing as I am not entirely sure how the middleware should behave in some cases. The cancel description in the Readme may also need to be updated.
## Third commit : Updated Readme.md with informations related to leading and trailing
- Added a section describing the `leading` and `trailing` options.
