### PR TITLE
Fix null meta

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,18 @@ export default () => {
   const timers = {};
 
   const middleware = () => dispatch => action => {
-    const { meta: { debounce = {} } = {}, type } = action;
+    const {
+      meta = {},
+      type,
+    } = action;
+
+    if (!meta) {
+      return dispatch(action);
+    }
+
+    const {
+      debounce = {},
+    } = meta
 
     const {
       time,

--- a/test/index.js
+++ b/test/index.js
@@ -111,14 +111,24 @@ describe("debounce middleware", () => {
     });
   });
 
-  describe("action is dispatched even has meta without debounce", () => {
-    beforeEach(() =>
-      store.dispatch({
-        type: "SEARCH",
-        payload: "foo",
-        meta: { other: "other" }
-      })
-    );
+  describe('null meta in action', () => {
+    beforeEach(() => store.dispatch({
+      type: 'SEARCH',
+      payload: 'foo',
+      meta: null
+    }));
+
+    it('action works fine still', () => {
+      assert.deepEqual(store.getState(), {query:'foo'});
+    });
+  });
+
+  describe('action is dispatched even has meta without debounce', () => {
+    beforeEach(() => store.dispatch({
+      type: 'SEARCH',
+      payload: 'foo',
+      meta: { other: 'other' }
+    }));
 
     it("state is updated straight away", () => {
       assert.deepEqual(store.getState(), { query: "foo" });


### PR DESCRIPTION
Right now, module doesn't covered the case when meta is null, which breaks the middleware by throwing an error (debounce on null object). this pr aims to fix this case via a safer getter, and the corresponding test case is added.
You can directly re-build and publish.